### PR TITLE
Fix minDate comparison: Compare only dates not times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nebenan-react-datepicker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-react-datepicker",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-react-datepicker/issues",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "reinstall": "rm -rf node_modules package-lock.json && npm install && npm run decache",
     "decache": "find ./build -type f -name '.browserify-cache.json' -delete || echo \"\\033[0;32mAlready decached!\\033[0m\"",

--- a/src/month_view.es
+++ b/src/month_view.es
@@ -24,7 +24,7 @@ const renderMonth = ({
   theme,
   month,
   minDate: providedMinDate,
-  maxDate: providedMaxDate,
+  maxDate,
   selected,
   onCellClick,
 }) => {
@@ -34,7 +34,6 @@ const renderMonth = ({
   const today = new Date();
 
   const minDate = providedMinDate && startOfDay(providedMinDate);
-  const maxDate = providedMaxDate && startOfDay(providedMaxDate);
 
   const renderWeek = (week) => {
     const shift = week * DAYS_COUNT;

--- a/src/month_view.es
+++ b/src/month_view.es
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import addMonths from 'date-fns/addMonths';
 import setDate from 'date-fns/setDate';
 import isSameDay from 'date-fns/isSameDay';
+import startOfDay from 'date-fns/startOfDay';
 import { arrayOf, getMonthDetails } from './utils';
 
 const DAYS_COUNT = 7;
@@ -19,11 +20,21 @@ const renderLabelsRow = (locale, theme) => {
   return <tr>{labels}</tr>;
 };
 
-const renderMonth = ({ theme, month, minDate, maxDate, selected, onCellClick }) => {
+const renderMonth = ({
+  theme,
+  month,
+  minDate: providedMinDate,
+  maxDate: providedMaxDate,
+  selected,
+  onCellClick,
+}) => {
   const { days, offset } = getMonthDetails(month);
 
   const weeks = Math.ceil((days + offset) / DAYS_COUNT);
   const today = new Date();
+
+  const minDate = providedMinDate && startOfDay(providedMinDate);
+  const maxDate = providedMaxDate && startOfDay(providedMaxDate);
 
   const renderWeek = (week) => {
     const shift = week * DAYS_COUNT;

--- a/test/index.js
+++ b/test/index.js
@@ -48,7 +48,7 @@ describe('MonthCalendar', () => {
       ...locale,
       theme,
       selected: new Date(2020, 3, 17),
-      minDate: new Date(2020, 2, 20),
+      minDate: new Date(2020, 2, 20, 12, 1, 10),
       onChange,
     };
 


### PR DESCRIPTION
https://jira.nebenan.de/browse/CORE-5490

(about the ticket: nebenan-frontend passes `new Date()` as `minDate`)

Users of this component would expect it to ignore any times in props (since it is a Datepicker, not a DatetimePicker)